### PR TITLE
Add atsphinx-mini18n extension

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,6 +17,7 @@
 - [Attribution](#attribution)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Our Pledge
 
 We as members, contributors, and leaders pledge to make participation in our

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,7 +17,6 @@
 - [Attribution](#attribution)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 ## Our Pledge
 
 We as members, contributors, and leaders pledge to make participation in our
@@ -78,7 +77,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-<tkoyama010@gmail.com>.
+tkoyama010@gmail.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
@@ -134,7 +133,7 @@ the community.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
-<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).
@@ -142,5 +141,5 @@ enforcement ladder](https://github.com/mozilla/diversity).
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see the FAQ at
-<https://www.contributor-covenant.org/faq>. Translations are available at
-<https://www.contributor-covenant.org/translations>.
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -77,7 +77,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-tkoyama010@gmail.com.
+<tkoyama010@gmail.com>.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
@@ -133,7 +133,7 @@ the community.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).
@@ -141,5 +141,5 @@ enforcement ladder](https://github.com/mozilla/diversity).
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.

--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ Contributions _very welcome_ but first see [Contributing](CONTRIBUTING.md).
 ## Fun & Entertainment
 
 - [sphinx-nekochan](https://github.com/takanory/sphinx-nekochan) - A Sphinx extension for adding the "Nekochan(cat) emoji" to documents. Adds cat emojis to your documentation using special syntax.
+
+## Internationalization
+
+- [atsphinx-mini18n](https://pypi.org/project/atsphinx-mini18n/) - A minimal internationalization extension for Sphinx. Part of the atsphinx ecosystem providing simplified i18n functionality.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Contributions _very welcome_ but first see [Contributing](CONTRIBUTING.md).
 
 - [Presentation](#presentation)
 - [Fun & Entertainment](#fun--entertainment)
+- [Internationalization](#internationalization)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 


### PR DESCRIPTION
## Summary
- Add atsphinx-mini18n extension to the Internationalization section
- Provides minimal internationalization support for Sphinx
- Part of the atsphinx ecosystem for simplified i18n functionality

## Test plan
- [x] Verify the extension link is working
- [x] Check that the description is accurate

🤖 Generated with [Claude Code](https://claude.ai/code)