### PR TITLE
Add sphinxcontrib-mermaid extension

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,7 +17,6 @@
 - [Attribution](#attribution)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 ## Our Pledge
 
 We as members, contributors, and leaders pledge to make participation in our
@@ -78,7 +77,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-<tkoyama010@gmail.com>.
+tkoyama010@gmail.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
@@ -134,7 +133,7 @@ the community.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
-<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).
@@ -142,5 +141,5 @@ enforcement ladder](https://github.com/mozilla/diversity).
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see the FAQ at
-<https://www.contributor-covenant.org/faq>. Translations are available at
-<https://www.contributor-covenant.org/translations>.
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -77,7 +77,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-tkoyama010@gmail.com.
+<tkoyama010@gmail.com>.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
@@ -133,7 +133,7 @@ the community.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).
@@ -141,5 +141,5 @@ enforcement ladder](https://github.com/mozilla/diversity).
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.

--- a/README.md
+++ b/README.md
@@ -21,18 +21,14 @@ Contributions _very welcome_ but first see [Contributing](CONTRIBUTING.md).
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Presentation
-
 - [sphinx-revealjs](https://github.com/attakei/sphinx-revealjs) - HTML Presentation builder for Pythonista. Generates reveal.js presentations from standard reStructuredText.
 
 ## Fun & Entertainment
-
 - [sphinx-nekochan](https://github.com/takanory/sphinx-nekochan) - A Sphinx extension for adding the "Nekochan(cat) emoji" to documents. Adds cat emojis to your documentation using special syntax.
 
 ## Internationalization
-
 - [atsphinx-mini18n](https://pypi.org/project/atsphinx-mini18n/) - A minimal internationalization extension for Sphinx. Part of the atsphinx ecosystem providing simplified i18n functionality.
 
 ## Visualization
-
 - [pyvista.ext.plot_directive](https://docs.pyvista.org/extras/plot_directive.html) - Sphinx extension for generating static and interactive 3D scenes using PyVista. Provides pyvista-plot directive for embedding 3D visualizations in documentation.
 - [pyvista.ext.viewer_directive](https://docs.pyvista.org/extras/plot_directive.html) - Companion extension for PyVista plot directive that enables interactive 3D scene viewing in documentation.

--- a/README.md
+++ b/README.md
@@ -30,5 +30,4 @@ Contributions _very welcome_ but first see [Contributing](CONTRIBUTING.md).
 - [atsphinx-mini18n](https://pypi.org/project/atsphinx-mini18n/) - A minimal internationalization extension for Sphinx. Part of the atsphinx ecosystem providing simplified i18n functionality.
 
 ## Visualization
-- [pyvista.ext.plot_directive](https://docs.pyvista.org/extras/plot_directive.html) - Sphinx extension for generating static and interactive 3D scenes using PyVista. Provides pyvista-plot directive for embedding 3D visualizations in documentation.
-- [pyvista.ext.viewer_directive](https://docs.pyvista.org/extras/plot_directive.html) - Companion extension for PyVista plot directive that enables interactive 3D scene viewing in documentation.
+- [pyvista](https://docs.pyvista.org/extras/plot_directive.html) - Sphinx extensions for generating static and interactive 3D scenes. Includes plot_directive and viewer_directive for embedding 3D visualizations in documentation.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,5 @@ Contributions _very welcome_ but first see [Contributing](CONTRIBUTING.md).
 - [atsphinx-mini18n](https://pypi.org/project/atsphinx-mini18n/) - A minimal internationalization extension for Sphinx. Part of the atsphinx ecosystem providing simplified i18n functionality.
 
 ## Visualization
-
-- [pyvista](https://docs.pyvista.org/extras/plot_directive.html) - Sphinx extensions for generating static and interactive 3D scenes. Includes plot_directive and viewer_directive for embedding 3D visualizations in documentation.
-- [sphinxcontrib-mermaid](https://github.com/mgaitan/sphinxcontrib-mermaid) - Embed Mermaid diagrams in Sphinx documentation. Supports flowcharts, sequence diagrams, gantt charts, and more with flexible output formats.
+- [pyvista](https://docs.pyvista.org/extras/plot_directive.html) - Sphinx extensions for generating static and interactive 3D scenes. Includes plot_directive and viewer_directive for 3D visualizations.
+- [sphinxcontrib-mermaid](https://github.com/mgaitan/sphinxcontrib-mermaid) - Embed Mermaid diagrams in Sphinx documentation. Supports flowcharts, sequence diagrams, gantt charts with flexible output formats.

--- a/README.md
+++ b/README.md
@@ -34,5 +34,6 @@ Contributions _very welcome_ but first see [Contributing](CONTRIBUTING.md).
 - [atsphinx-mini18n](https://pypi.org/project/atsphinx-mini18n/) - A minimal internationalization extension for Sphinx. Part of the atsphinx ecosystem providing simplified i18n functionality.
 
 ## Visualization
+
 - [pyvista](https://docs.pyvista.org/extras/plot_directive.html) - Sphinx extensions for generating static and interactive 3D scenes. Includes plot_directive and viewer_directive for 3D visualizations.
 - [sphinxcontrib-mermaid](https://github.com/mgaitan/sphinxcontrib-mermaid) - Embed Mermaid diagrams in Sphinx documentation. Supports flowcharts, sequence diagrams, gantt charts with flexible output formats.

--- a/README.md
+++ b/README.md
@@ -31,3 +31,4 @@ Contributions _very welcome_ but first see [Contributing](CONTRIBUTING.md).
 
 ## Visualization
 - [pyvista](https://docs.pyvista.org/extras/plot_directive.html) - Sphinx extensions for generating static and interactive 3D scenes. Includes plot_directive and viewer_directive for embedding 3D visualizations in documentation.
+- [sphinxcontrib-mermaid](https://github.com/mgaitan/sphinxcontrib-mermaid) - Embed Mermaid diagrams in Sphinx documentation. Supports flowcharts, sequence diagrams, gantt charts, and more with flexible output formats.

--- a/README.md
+++ b/README.md
@@ -31,3 +31,8 @@ Contributions _very welcome_ but first see [Contributing](CONTRIBUTING.md).
 ## Internationalization
 
 - [atsphinx-mini18n](https://pypi.org/project/atsphinx-mini18n/) - A minimal internationalization extension for Sphinx. Part of the atsphinx ecosystem providing simplified i18n functionality.
+
+## Visualization
+
+- [pyvista.ext.plot_directive](https://docs.pyvista.org/extras/plot_directive.html) - Sphinx extension for generating static and interactive 3D scenes using PyVista. Provides pyvista-plot directive for embedding 3D visualizations in documentation.
+- [pyvista.ext.viewer_directive](https://docs.pyvista.org/extras/plot_directive.html) - Companion extension for PyVista plot directive that enables interactive 3D scene viewing in documentation.

--- a/README.md
+++ b/README.md
@@ -17,18 +17,23 @@ Contributions _very welcome_ but first see [Contributing](CONTRIBUTING.md).
 - [Presentation](#presentation)
 - [Fun & Entertainment](#fun--entertainment)
 - [Internationalization](#internationalization)
+- [Visualization](#visualization)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Presentation
+
 - [sphinx-revealjs](https://github.com/attakei/sphinx-revealjs) - HTML Presentation builder for Pythonista. Generates reveal.js presentations from standard reStructuredText.
 
 ## Fun & Entertainment
+
 - [sphinx-nekochan](https://github.com/takanory/sphinx-nekochan) - A Sphinx extension for adding the "Nekochan(cat) emoji" to documents. Adds cat emojis to your documentation using special syntax.
 
 ## Internationalization
+
 - [atsphinx-mini18n](https://pypi.org/project/atsphinx-mini18n/) - A minimal internationalization extension for Sphinx. Part of the atsphinx ecosystem providing simplified i18n functionality.
 
 ## Visualization
+
 - [pyvista](https://docs.pyvista.org/extras/plot_directive.html) - Sphinx extensions for generating static and interactive 3D scenes. Includes plot_directive and viewer_directive for embedding 3D visualizations in documentation.
 - [sphinxcontrib-mermaid](https://github.com/mgaitan/sphinxcontrib-mermaid) - Embed Mermaid diagrams in Sphinx documentation. Supports flowcharts, sequence diagrams, gantt charts, and more with flexible output formats.


### PR DESCRIPTION
## Summary
- Add sphinxcontrib-mermaid extension to the Visualization section
- Enables embedding Mermaid diagrams in Sphinx documentation
- Supports flowcharts, sequence diagrams, gantt charts, and more
- Provides flexible output formats (raw, PNG, SVG)

## Test plan
- [x] Verify the extension link is working
- [x] Check that the description is accurate

🤖 Generated with [Claude Code](https://claude.ai/code)